### PR TITLE
Forget to #include <stdint.h>

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <unistd.h>
 


### PR DESCRIPTION
uint16_t and UINT16_MAX is defined in header ‘<stdint.h>’